### PR TITLE
fix: adicionar rota do endpoint network security no main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,6 +123,7 @@ func main() {
 	router.POST("/scan", handler.CreateScanJob)
 	router.GET("/health", handler.HealthHandler)
 	router.GET("/metrics", handler.MetricsHandler)
+	router.GET("/api/v1/scans/:id/network", handler.GetNetworkSecurity)
 	
 	// Swagger documentation
 	router.Static("/docs", "./docs")


### PR DESCRIPTION
## Summary
- Adiciona a rota faltante para o endpoint de network security no main.go
- Corrige problema identificado durante testes manuais

## Contexto
Durante os testes manuais do PR #13, foi identificado que a rota `/api/v1/scans/:id/network` não estava registrada no arquivo `main.go`, causando erro 404 ao tentar acessar o endpoint.

## Mudança
Adiciona a linha:
```go
router.GET("/api/v1/scans/:id/network", handler.GetNetworkSecurity)
```

## Test Plan
- [x] Endpoint testado manualmente com Docker
- [x] Retorna corretamente os 8 campos de network security
- [x] Tratamento de erros funcionando (404 para scan não encontrado, 400 para UUID inválido)

🤖 Generated with [Claude Code](https://claude.ai/code)